### PR TITLE
Added POST request to payment requests and set it to be used by default.

### DIFF
--- a/src/AbstractApi.php
+++ b/src/AbstractApi.php
@@ -82,14 +82,14 @@ abstract class AbstractApi
      *
      * @var Request
      */
-    private $request;
+    protected $request;
 
     /**
      * Response of the call
      *
      * @var Response
      */
-    private $response;
+    protected $response;
 
     /**
      * Base url
@@ -103,14 +103,14 @@ abstract class AbstractApi
      *
      * @var Authentication
      */
-    private $authentication;
+    protected $authentication;
 
     /**
      * HTTP client to use
      *
      * @var ClientInterface
      */
-    private $httpClient;
+    protected $httpClient;
 
     /**
      * Configure options
@@ -354,7 +354,7 @@ abstract class AbstractApi
      *
      * @return Client
      */
-    private function getClient()
+    protected function getClient()
     {
         return $this->httpClient;
     }

--- a/tests/Api/PaymentRequestTest.php
+++ b/tests/Api/PaymentRequestTest.php
@@ -67,8 +67,8 @@ class PaymentRequestTest extends AbstractApiTest
         $api->setCurrency(957);
         $api->setShopOrderId('order id');
         $api->setTerminal('my terminal');
-
         $api->setLanguage('da');
+
         $api->setType('payment');
         $cctoken = $this->randomString(41);
         $api->setCcToken($cctoken);
@@ -90,7 +90,27 @@ class PaymentRequestTest extends AbstractApiTest
 
         $this->assertEquals($this->getExceptedUri('createPaymentRequest/'), $request->getUri()->getPath());
         parse_str($request->getUri()->getQuery(), $parts);
+
+        foreach(PaymentRequest::REQUIRED_QUERY_PARAMS as $QUERY_PARAM){
+            $this->assertArrayHasKey($QUERY_PARAM,$parts,'Create Payment Request is missing the "'.$QUERY_PARAM.'" query parameter.');
+        }
+
         $this->assertEquals('da', $parts['language']);
+
+        $this->assertTrue(is_numeric($parts['amount']),'Amount is not numeric');
+
+        $this->assertTrue(is_numeric($parts['currency']),'Currency is not numeric');
+
+        $this->assertEquals('my terminal', $parts['terminal']);
+        $this->assertEquals('order id', $parts['shop_orderid']);
+        $this->assertEquals(200.50, ((float)$parts['amount']));
+        $this->assertEquals(957, ((int)$parts['currency']));
+
+        if(strtolower($request->getMethod()) == 'post'){
+            unset($parts);
+            parse_str($request->getBody()->getContents(),$parts);
+        }
+
         $this->assertEquals('payment', $parts['type']);
         $this->assertEquals($cctoken, $parts['ccToken']);
         $this->assertEquals('identifier', $parts['sale_reconciliation_identifier']);


### PR DESCRIPTION
This fixes the 400 bad request issue that was happening when people would have alot of orderlines in their payment requests.
This adds the possibility to use post on payment requests and sets that as the default.
This also removed some private methods and properties in the AbstractApi class.
Also modified the test to test the request if it is post.