### PR TITLE
FIXED: Norwegian language not always automatically converted

### DIFF
--- a/src/Types/LanguageTypes.php
+++ b/src/Types/LanguageTypes.php
@@ -34,7 +34,7 @@ class LanguageTypes implements TypeInterface
      */
     private static $languages = [
 	    'cs', 'da', 'de', 'en', 'es', 'fi', 'fr', 'ja',
-	    'lt', 'nl', 'nn', 'pl', 'sv','th', 'tr', 'zh',
+	    'lt', 'nb', 'nl', 'nn', 'no', 'pl', 'sv','th', 'tr', 'zh',
 	    'et', 'ee', 'it', 'pt', 'eu'
     ];
 


### PR DESCRIPTION
In a setup of Magento 2.3.2 and PHP 7.2 we had a problem where the language-code was not automatically converted.